### PR TITLE
fix inplace resize in beam search leading to deprecation warnings

### DIFF
--- a/onmt/inference/fast_translator.py
+++ b/onmt/inference/fast_translator.py
@@ -544,7 +544,7 @@ class FastTranslator(Translator):
             torch.masked_select(
                 cand_bbsz_idx[:, :beam_size],
                 mask=eos_mask[:, :beam_size],
-                out=eos_bbsz_idx,
+                out=eos_bbsz_idx.resize_(0),
             )
 
             finalized_sents = set()
@@ -552,7 +552,7 @@ class FastTranslator(Translator):
                 torch.masked_select(
                     cand_scores[:, :beam_size],
                     mask=eos_mask[:, :beam_size],
-                    out=eos_scores,
+                    out=eos_scores.resize_(0),
                 )
                 finalized_sents = finalize_hypos(step, eos_bbsz_idx, eos_scores)
                 num_remaining_sent -= len(finalized_sents)
@@ -602,7 +602,7 @@ class FastTranslator(Translator):
             torch.add(
                 eos_mask.type_as(cand_offsets) * cand_size,
                 cand_offsets[:eos_mask.size(1)],
-                out=active_mask,
+                out=active_mask.resize_(0),
             )
 
             # get the top beam_size active hypotheses, which are just the hypos
@@ -610,7 +610,7 @@ class FastTranslator(Translator):
             active_hypos, new_blacklist = buffer('active_hypos'), buffer('new_blacklist')
             torch.topk(
                 active_mask, k=beam_size, dim=1, largest=False,
-                out=(new_blacklist, active_hypos)
+                out=(new_blacklist.resize_(0), active_hypos.resize_(0))
             )
 
             # update blacklist to ignore any finalized hypos
@@ -620,7 +620,7 @@ class FastTranslator(Translator):
             active_bbsz_idx = buffer('active_bbsz_idx')
             torch.gather(
                 cand_bbsz_idx, dim=1, index=active_hypos,
-                out=active_bbsz_idx,
+                out=active_bbsz_idx.resize_(0),
             )
             active_scores = torch.gather(
                 cand_scores, dim=1, index=active_hypos,

--- a/onmt/inference/search.py
+++ b/onmt/inference/search.py
@@ -89,7 +89,7 @@ class BeamSearch(Search):
                 beam_size * 2,
                 lprobs.view(bsz, -1).size(1) - beam_size,  # -beam_size so we never select pad (beam_size times)
             ),
-            out=(self.scores_buf, self.indices_buf),
+            out=(self.scores_buf.resize_(0), self.indices_buf.resize_(0)),
         )
 
         # torch.div(self.indices_buf, vocab_size, out=self.beams_buf)


### PR DESCRIPTION
As per the discussion in this [issue](https://github.com/pytorch/pytorch/issues/41027) resizing in-place via `out=` prints a deprecation warning in recent versions of PyTorch.
According to the warning and this [pytorch developer FAQ](https://github.com/pytorch/pytorch/wiki/Developer-FAQ#how-does-out-work-in-pytorch) the proper fix is to resize the target tensor to zero-size, since that's PyTorch's "out= contract".